### PR TITLE
Update 1、BeanDefinition的资源定位过程.md

### DIFF
--- a/docs/Spring/IoC/1、BeanDefinition的资源定位过程.md
+++ b/docs/Spring/IoC/1、BeanDefinition的资源定位过程.md
@@ -261,7 +261,7 @@ AbstractBeanDefinitionReader 中对 loadBeanDefinitions 方法的各种重载及
  */
 public int loadBeanDefinitions(String... locations) throws BeanDefinitionStoreException {
     Assert.notNull(locations, "Location array must not be null");
-    // 计数器，统计加载了多少个配置文件
+    // 计数器，统计加载了多少个BeanDefinition
     int counter = 0;
     for (String location : locations) {
         counter += loadBeanDefinitions(location);


### PR DESCRIPTION
看调用方法返回的是加载BeanDefinition的个数，而不是配置文件个数