### PR TITLE
Update nacos document

### DIFF
--- a/docs/nacos/nacos-discovery.md
+++ b/docs/nacos/nacos-discovery.md
@@ -10,7 +10,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.alibaba.boot.nacos.discovery.autoconfigure.NacosDiscoveryAutoConfiguration
 ```
 
-找到类`NacosDiscoveryAutoConfiguration`
+找到类 `NacosDiscoveryAutoConfiguration`
 
 ```java
 @ConditionalOnProperty(name = NacosDiscoveryConstants.ENABLED, matchIfMissing = true)

--- a/docs/nacos/nacos-discovery.md
+++ b/docs/nacos/nacos-discovery.md
@@ -10,7 +10,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.alibaba.boot.nacos.discovery.autoconfigure.NacosDiscoveryAutoConfiguration
 ```
 
-找到注解`NacosDiscoveryAutoConfiguration`
+找到类`NacosDiscoveryAutoConfiguration`
 
 ```java
 @ConditionalOnProperty(name = NacosDiscoveryConstants.ENABLED, matchIfMissing = true)


### PR DESCRIPTION
I think it is better  modified to class ,Because `NacosDiscoveryAutoConfiguration` is a class not a annotation

thus,it is better clear