### PR TITLE
fix: update BeanFactoryPostProcessor.md

### DIFF
--- a/docs/LearningExperience/EncodingSpecification/一个程序员的自我修养.md
+++ b/docs/LearningExperience/EncodingSpecification/一个程序员的自我修养.md
@@ -91,7 +91,7 @@
 - 常量的复用层次有五层：跨应用共享常量、应用内共享常量、子工程内共享常量、包内共享常量、类内共享常量。  
   1）跨应用共享常量：放置在二方库中，通常是 client.jar 中的 constant 目录下。  
   2）应用内共享常量：放置在一方库中，通常是子模块中的 constant 目录下。  
-  反例：易懂变量也要统一定义成应用内共享常量，两位攻城师在两个类中分别定义了表示 “是” 的变量。  
+  反例：易懂变量也要统一定义成应用内共享常量，两位工程师在两个类中分别定义了表示 “是” 的变量。  
   类 A 中：public static final String YES = "yes"；  
   类 B 中：public static final String YES = "y"；  
   A.YES.equals(B.YES)，预期是 true，但实际返回为 false，导致线上问题。  
@@ -155,7 +155,7 @@ public enum SeasonEnum {
   反例：比如显示成交总额涨跌情况，即正负 x%，x 为基本数据类型，调用的 RPC 服务，调用不成功时，返回的是默认值，页面显示为 0%，这是不合理的，应该显示成中划线。所以包装数据类型的 null 值，能够表示额外的信息，如：远程调用失败，异常退出。
 
 - 定义 DO/DTO/VO 等 POJO 类时，不要设定任何属性默认值。  
-  反例：POJO 类的 gmtCreate 默认值为 new Date()，但是这个属性在数据提取时并没有置入具 体值，在更新其它字段时又附带更新了此字段，导致创建时间被修改成当前时间。
+  反例：POJO 类的 gmtCreate 默认值为 new Date()，但是这个属性在数据提取时并没有置入具体值，在更新其它字段时又附带更新了此字段，导致创建时间被修改成当前时间。
 
 - 序列化类新增属性时，请不要修改 serialVersionUID 字段，避免反序列化失败；如果完全不兼容升级，避免反序列化混乱，那么请修改 serialVersionUID 值。  
   说明：注意 serialVersionUID 不一致会抛出序列化运行时异常。
@@ -194,7 +194,7 @@ public enum SeasonEnum {
   6） 若是 static 成员变量，考虑是否为 final。  
   7） 类成员方法只供类内部调用，必须是 private。  
   8） 类成员方法只对继承类公开，那么限制为 protected。 说明：任何类、方法、参数、变量，严控访问范围。过于宽泛的访问范围，不利于模块解耦。  
-  思考：如果是一个 private 的方法，想删除就删除，可是一个 public 的 service 成员方法或成员变量，删除一下，不得手心冒点汗吗？变量像自己的小孩，尽量在自己的视线内，变量作 用域太大，无限制的到处跑，那么你会担心的。
+  思考：如果是一个 private 的方法，想删除就删除，可是一个 public 的 service 成员方法或成员变量，删除一下，不得手心冒点汗吗？变量像自己的小孩，尽量在自己的视线内，变量作用域太大，无限制的到处跑，那么你会担心的。
 
 ### 1.5 集合处理
 
@@ -739,7 +739,7 @@ logger.debug("Processing trade with id: {} and symbol : {} ", id, symbol);
 
 ### 3.2 SQL 语句
 
-- 不要使用 count(列名)或 count(常量)来替代 count(_)，count(_)是 SQL92 定义的 标准统计行数的语法，跟数据库无关，跟 NULL 和非 NULL 无关。  
+- 不要使用 count(列名)或 count(常量)来替代 count(\*)，count(\*)是 SQL92 定义的 标准统计行数的语法，跟数据库无关，跟 NULL 和非 NULL 无关。  
   说明：**count(\*)会统计值为 NULL 的行，而 count(列名)不会统计此列为 NULL 值的行**。
 
 - **count(distinct col) 计算该列除 NULL 之外的不重复行数，注意 count(distinct col1, col2) 如果其中一列全为 NULL，那么即使另一列有不同的值，也返回为 0**。

--- a/docs/Spring/IoC/BeanFactoryPostProcessor.md
+++ b/docs/Spring/IoC/BeanFactoryPostProcessor.md
@@ -190,8 +190,8 @@ package cn.demo1;
 @Getter
 @ToString
 public class Address {
+    private String province;
     private String city;
-    private String town;
 }
 
 ```


### PR DESCRIPTION
Address的属性名与AddressParse.setAsText方法中的名称保持一致